### PR TITLE
Remove distribution from package name

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -1,6 +1,5 @@
 #!/usr/bin/make -f
 
-DISTRIBUTION = $(shell lsb_release -sc)
 VERSION = 1.14.1
 PACKAGEVERSION = $(VERSION)-0
 TARBALL = kubernetes.tar.gz

--- a/debian/rules
+++ b/debian/rules
@@ -2,7 +2,7 @@
 
 DISTRIBUTION = $(shell lsb_release -sc)
 VERSION = 1.14.1
-PACKAGEVERSION = $(VERSION)-0~$(DISTRIBUTION)0
+PACKAGEVERSION = $(VERSION)-0
 TARBALL = kubernetes.tar.gz
 URL = https://github.com/kubernetes/kubernetes/releases/download/v$(VERSION)/$(TARBALL)
 


### PR DESCRIPTION
In order to be compliant with Semantic Versioning this commit remove
~$(DISTRIBUTION) from the package name.

This will also make the package compliant with XIP025

[ch1917]