### PR TITLE
debian: FIX broken packages (kubectl <-> kubelet, kubernetes-master)

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+kubernetes (1.19.4-0+exo4) UNRELEASED; urgency=low
+
+  * debian: FIX broken packages (kubectl <-> kubelet, kubernetes-master)
+
+ -- Cédric Dufour <cedric.dufour@exoscale.ch>  Fri, 20 Nov 2020 13:04:43 +0100
+
 kubernetes (1.19.4-0+exo1) UNRELEASED; urgency=medium
 
   * debian: packaging v2

--- a/debian/control
+++ b/debian/control
@@ -32,7 +32,7 @@ Description: Kubernetes Node Components - kubelet
 
 Package: kubectl
 Architecture: any
-Conflicts: kubelet (<< 1.19.4-0+exo1), kubernetes-master (<< 1.19.4-0+exo1)
+Breaks: kubelet (<< 1.19.4-0+exo4~), kubernetes-master (<< 1.19.4-0+exo4~)
 Description: Kubernetes command-line client
 
 Package: kubernetes-master


### PR DESCRIPTION
CI: https://ci.internal.exoscale.ch/job/pkg-kubernetes/77/consoleFull

**kube-node:**
```
* root@kube-node-lab1-fb0d0-guwll.gv2.p.exoscale.net:~
# apt-get install -s kubelet
Reading package lists... Done
Building dependency tree       
Reading state information... Done
Some packages could not be installed. This may mean that you have
requested an impossible situation or if you are using the unstable
distribution that some required packages have not yet been created
or been moved out of Incoming.
The following information may help to resolve the situation:

The following packages have unmet dependencies:
 kubelet : Depends: kubectl (= 1.19.4-0+exo1~focal) but it is not going to be installed
E: Unable to correct problems, you have held broken packages.
@ 2020-11-20 12:00:25 +0000

* root@kube-node-lab1-fb0d0-guwll.gv2.p.exoscale.net:~
# apt-get install -s kubelet -t focal-test1
Reading package lists... Done
Building dependency tree       
Reading state information... Done
The following packages were automatically installed and are no longer required:
  libaccountsservice0 libestr0 libfastjson4 libnetplan0 squashfs-tools
Use 'apt autoremove' to remove them.
The following additional packages will be installed:
  kube-common kubectl
The following NEW packages will be installed:
  kube-common kubectl
The following held packages will be changed:
  kubelet
The following packages will be upgraded:
  kubelet
1 upgraded, 2 newly installed, 0 to remove and 13 not upgraded.
Inst kube-common (1.19.4-0+exo3~focal exoscale-test1:focal-test1 [all])
Inst kubelet [1.19.3-0] (1.19.4-0+exo3~focal exoscale-test1:focal-test1 [amd64]) []
Inst kubectl (1.19.4-0+exo3~focal exoscale-test1:focal-test1 [amd64])
Conf kube-common (1.19.4-0+exo3~focal exoscale-test1:focal-test1 [all])
Conf kubelet (1.19.4-0+exo3~focal exoscale-test1:focal-test1 [amd64])
Conf kubectl (1.19.4-0+exo3~focal exoscale-test1:focal-test1 [amd64])
@ 2020-11-20 12:00:30 +0000
```

**kube-master:**
```
* root@kube-master-lab003.gv2.p.exoscale.net:~
# apt-get install -s kubernetes-master 
Reading package lists... Done
Building dependency tree       
Reading state information... Done
Some packages could not be installed. This may mean that you have
requested an impossible situation or if you are using the unstable
distribution that some required packages have not yet been created
or been moved out of Incoming.
The following information may help to resolve the situation:

The following packages have unmet dependencies:
 kubernetes-master : Depends: kubectl (= 1.19.4-0+exo1~focal) but it is not going to be installed
E: Unable to correct problems, you have held broken packages.
@ 2020-11-20 12:09:39 +0000

* root@kube-master-lab003.gv2.p.exoscale.net:~
# apt-get install -s kubernetes-master -t focal-test1
Reading package lists... Done
Building dependency tree       
Reading state information... Done
The following packages were automatically installed and are no longer required:
  libaccountsservice0 libestr0 libfastjson4 libnetplan0 squashfs-tools
Use 'apt autoremove' to remove them.
The following additional packages will be installed:
  kube-apiserver kube-common kube-controller-manager kube-scheduler kubectl
The following NEW packages will be installed:
  kube-apiserver kube-common kube-controller-manager kube-scheduler kubectl
The following held packages will be changed:
  kubernetes-master
The following packages will be upgraded:
  kubernetes-master
1 upgraded, 5 newly installed, 0 to remove and 22 not upgraded.
Inst kube-common (1.19.4-0+exo3~focal exoscale-test1:focal-test1 [all])
Inst kube-apiserver (1.19.4-0+exo3~focal exoscale-test1:focal-test1 [amd64])
Inst kube-controller-manager (1.19.4-0+exo3~focal exoscale-test1:focal-test1 [amd64])
Inst kube-scheduler (1.19.4-0+exo3~focal exoscale-test1:focal-test1 [amd64])
Inst kubernetes-master [1.19.3-0] (1.19.4-0+exo3~focal exoscale-test1:focal-test1 [all]) []
Inst kubectl (1.19.4-0+exo3~focal exoscale-test1:focal-test1 [amd64])
Conf kube-common (1.19.4-0+exo3~focal exoscale-test1:focal-test1 [all])
Conf kube-apiserver (1.19.4-0+exo3~focal exoscale-test1:focal-test1 [amd64])
Conf kube-controller-manager (1.19.4-0+exo3~focal exoscale-test1:focal-test1 [amd64])
Conf kube-scheduler (1.19.4-0+exo3~focal exoscale-test1:focal-test1 [amd64])
Conf kubernetes-master (1.19.4-0+exo3~focal exoscale-test1:focal-test1 [all])
Conf kubectl (1.19.4-0+exo3~focal exoscale-test1:focal-test1 [amd64])
@ 2020-11-20 12:09:46 +0000
```
