### PR TITLE
debian: FIX services configuration and ADD kubeadm package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ semantic.cache
 /debian/kube-scheduler
 /debian/kubelet
 /debian/kubectl
+/debian/kubeadm
 /debian/kubernetes-master
 # ... built resources
 /download

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+kubernetes (1.19.4-0+exo5) UNRELEASED; urgency=low
+
+  * debian: FIX services configuration and ADD 'kubeadm' package
+
+ -- Cédric Dufour <cedric.dufour@exoscale.ch>  Tue, 24 Nov 2020 11:22:01 +0100
+
 kubernetes (1.19.4-0+exo4) UNRELEASED; urgency=low
 
   * debian: FIX broken packages (kubectl <-> kubelet, kubernetes-master)

--- a/debian/control
+++ b/debian/control
@@ -35,10 +35,14 @@ Architecture: any
 Breaks: kubelet (<< 1.19.4-0+exo4~), kubernetes-master (<< 1.19.4-0+exo4~)
 Description: Kubernetes command-line client
 
+Package: kubeadm
+Architecture: any
+Description: Kubernetes administration toolbox
+
 Package: kubernetes-master
 Architecture: all
 Depends: kube-apiserver (= ${binary:Version}),
          kube-controller-manager (= ${binary:Version}),
          kube-scheduler (= ${binary:Version}),
          kubectl (= ${binary:Version})
-Description: Kubernetes Master Components - Full Control Plane
+Description: Kubernetes Master Components - Full Control Plane (metapackage)

--- a/debian/kube-apiserver.default
+++ b/debian/kube-apiserver.default
@@ -31,15 +31,19 @@ PROXY_CLIENT_CERT_FILE='/etc/kubernetes/apiserver/ssl/cert.pem'
 PROXY_CLIENT_KEY_FILE='/etc/kubernetes/apiserver/ssl/key.pem'
 
 # Kubeconfig
-AUTHENTICATION_KUBECONFIG='/etc/kubernetes/apiserver/kubeconfig'
-AUTHORIZATION_KUBECONFIG='/etc/kubernetes/apiserver/kubeconfig'
+#ADMISSION_CONTROL_CONFIG_FILE='/etc/kubernetes/apiserver/admission.kubeconfig'
+#AUTHENTICATION_TOKEN_WEBHOOK_CONFIG_FILE='/etc/kubernetes/apiserver/webhook.kubeconfig'
+#AUTHORIZATION_WEBHOOK_CONFIG_FILE='/etc/kubernetes/apiserver/webhook.kubeconfig'
+#EGRESS_SELECTOR_CONFIG_FILE='/etc/kubernetes/apiserver/egress.kubeconfig'
 
 # ETCD
 ETCD_PREFIX='/kubernetes'
 ETCD_SERVERS='https://127.0.0.1:2379'
 
 # Service account
-SERVICE_ACCOUNT_KEY_FILE='/etc/kubernetes/ssl/service-account-key.pem'
+SERVICE_ACCOUNT_SIGNING_KEY_FILE='/etc/kubernetes/service-account-key.pem'
+SERVICE_ACCOUNT_KEY_FILE='/etc/kubernetes/service-account-key.pem'
+SERVICE_ACCOUNT_ISSUER='default.svc.kube.example.org'
 
 # Features
 RUNTIME_CONFIG='api/all=true'

--- a/debian/kube-controller-manager.default
+++ b/debian/kube-controller-manager.default
@@ -14,8 +14,8 @@ SECURE_PORT=10257
 TLS_MIN_VERSION='VersionTLS13'
 TLS_CERT_FILE='/etc/kubernetes/controller-manager/ssl/cert+chain.pem'
 TLS_PRIVATE_KEY_FILE='/etc/kubernetes/controller-manager/ssl/key.pem'
-ROOT_CA_FILE='/etc/kubernetes/ssl/api-cas.pem' \
-CLIENT_CA_FILE='/etc/kubernetes/controller-manager/ssl/client-cas.pem' \
+ROOT_CA_FILE='/etc/kubernetes/ssl/api-cas.pem'
+CLIENT_CA_FILE='/etc/kubernetes/controller-manager/ssl/client-cas.pem'
 
 # Kubeconfig
 AUTHENTICATION_KUBECONFIG='/etc/kubernetes/controller-manager/kubeconfig'
@@ -23,7 +23,7 @@ AUTHORIZATION_KUBECONFIG='/etc/kubernetes/controller-manager/kubeconfig'
 
 # Service account
 USE_SERVICE_ACCOUNT_CREDENTIALS=true
-SERVICE_ACCOUNT_PRIVATE_KEY_FILE='/etc/kubernetes/ssl/service-account-key.pem'
+SERVICE_ACCOUNT_PRIVATE_KEY_FILE='/etc/kubernetes/service-account-key.pem'
 
 # Features
 CONTROLLERS='*,tokencleaner'

--- a/debian/kubeadm.install
+++ b/debian/kubeadm.install
@@ -1,0 +1,1 @@
+kubernetes/server/bin/kubeadm usr/bin

--- a/debian/rules
+++ b/debian/rules
@@ -18,7 +18,8 @@ DOWNLOAD_INSTALLER := ./download/cluster/get-kube-binaries.sh
 $(DOWNLOAD_INSTALLER):
 	mkdir -p ./download
 	wget --progress=dot:mega "$(TARBALL_URL)" -O "./download/$(TARBALL)"
-	tar -C ./download --strip-components=1 -xf "./download/$(TARBALL)"
+	tar -C ./download --strip-components=1 -xf "./download/$(TARBALL)" \
+	  --wildcards '*/version' '*/cluster/get-kube-binaries.sh'
 
 DOWNLOAD_TARBALL := ./download/server/kubernetes-server-linux-$(DEB_BUILD_ARCH).tar.gz
 $(DOWNLOAD_TARBALL): $(DOWNLOAD_INSTALLER)
@@ -28,7 +29,7 @@ $(DOWNLOAD_TARBALL): $(DOWNLOAD_INSTALLER)
 	${DOWNLOAD_INSTALLER}
 
 override_dh_auto_build: $(DOWNLOAD_TARBALL)
-	tar -xf "${DOWNLOAD_TARBALL}"
+	tar -xf "${DOWNLOAD_TARBALL}" --wildcards '*/server/bin/*'
 	kubernetes/server/bin/kubectl completion bash > kubectl.bash_completion
 
 # Restarting any Kubernetes component is something we want to do manually


### PR DESCRIPTION
CI: https://ci.internal.exoscale.ch/job/pkg-kubernetes/79/consoleFull
```
* cdufour@xps13-9380.cedric.exoscale.me:~/github/exoscale/pkg-kubernetes (cedric/ch22294/debian-even-better-focal)
$ dpkg-buildpackage -us -uc -b
dpkg-buildpackage: info: source package kubernetes
dpkg-buildpackage: info: source version 1.19.4-0+exo5
dpkg-buildpackage: info: source distribution UNRELEASED
dpkg-buildpackage: info: source changed by Cédric Dufour <cedric.dufour@exoscale.ch>
dpkg-buildpackage: info: host architecture amd64
 dpkg-source --before-build .
 fakeroot debian/rules clean
dh clean --with=systemd,bash-completion
   debian/rules override_dh_clean
make[1]: Entering directory '/local/data/encrypted/github/exoscale/pkg-kubernetes'
dh_clean
rm -rf ./kubernetes kubectl.bash_completion
make[1]: Leaving directory '/local/data/encrypted/github/exoscale/pkg-kubernetes'
 debian/rules build
dh build --with=systemd,bash-completion
   dh_update_autotools_config
   debian/rules override_dh_auto_build
make[1]: Entering directory '/local/data/encrypted/github/exoscale/pkg-kubernetes'
mkdir -p ./download
wget --progress=dot:mega "https://github.com/kubernetes/kubernetes/releases/download/v1.19.4/kubernetes.tar.gz" -O "./download/kubernetes.tar.gz"
--2020-11-24 11:27:46--  https://github.com/kubernetes/kubernetes/releases/download/v1.19.4/kubernetes.tar.gz
Resolving github.com (github.com)... 140.82.121.3
Connecting to github.com (github.com)|140.82.121.3|:443... connected.
HTTP request sent, awaiting response... 302 Found
Location: https://github-production-release-asset-2e65be.s3.amazonaws.com/20580498/b1dd0380-244f-11eb-886f-ddc092f83e91?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20201124%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20201124T102755Z&X-Amz-Expires=300&X-Amz-Signature=d13ea29c7ebbe4ede8e89befde7a85028f4613504b25129abdaec18517ef62ee&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=20580498&response-content-disposition=attachment%3B%20filename%3Dkubernetes.tar.gz&response-content-type=application%2Foctet-stream [following]
--2020-11-24 11:27:46--  https://github-production-release-asset-2e65be.s3.amazonaws.com/20580498/b1dd0380-244f-11eb-886f-ddc092f83e91?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20201124%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20201124T102755Z&X-Amz-Expires=300&X-Amz-Signature=d13ea29c7ebbe4ede8e89befde7a85028f4613504b25129abdaec18517ef62ee&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=20580498&response-content-disposition=attachment%3B%20filename%3Dkubernetes.tar.gz&response-content-type=application%2Foctet-stream
Resolving github-production-release-asset-2e65be.s3.amazonaws.com (github-production-release-asset-2e65be.s3.amazonaws.com)... 52.216.154.36
Connecting to github-production-release-asset-2e65be.s3.amazonaws.com (github-production-release-asset-2e65be.s3.amazonaws.com)|52.216.154.36|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 495287 (484K) [application/octet-stream]
Saving to: ‘./download/kubernetes.tar.gz’

     0K .......                                              100% 1.19M=0.4s

2020-11-24 11:27:47 (1.19 MB/s) - ‘./download/kubernetes.tar.gz’ saved [495287/495287]

tar -C ./download --strip-components=1 -xf "./download/kubernetes.tar.gz" \
  --wildcards '*/version' '*/cluster/get-kube-binaries.sh'
KUBERNETES_SERVER_ARCH=amd64 \
KUBERNETES_CLIENT_ARCH=amd64 \
KUBERNETES_SKIP_CONFIRM=YES \
./download/cluster/get-kube-binaries.sh
Kubernetes release: v1.19.4
Server: linux/amd64  (to override, set KUBERNETES_SERVER_ARCH)
Client: linux/amd64  (to override, set KUBERNETES_CLIENT_OS and/or KUBERNETES_CLIENT_ARCH)

Will download kubernetes-server-linux-amd64.tar.gz from https://dl.k8s.io/v1.19.4
Will download and extract kubernetes-client-linux-amd64.tar.gz from https://dl.k8s.io/v1.19.4
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   161  100   161    0     0   1192      0 --:--:-- --:--:-- --:--:--  1192
100  295M  100  295M    0     0  6100k      0  0:00:49  0:00:49 --:--:-- 5979k

md5sum(kubernetes-server-linux-amd64.tar.gz)=407272c37a7368d9fdbb7330fdedd739
sha512sum(kubernetes-server-linux-amd64.tar.gz)=fc9de14121af682af167ef99ce8a3803c25e92ef4739ed7eb592eadb30086b2cb9ede51d57816d1c3835f6202753d726eba804b839ae9cd516eff4e94c81c189

  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   161  100   161    0     0   1201      0 --:--:-- --:--:-- --:--:--  1201
100 12.0M  100 12.0M    0     0  5379k      0  0:00:02  0:00:02 --:--:-- 6227k

md5sum(kubernetes-client-linux-amd64.tar.gz)=b725bba2ffa5e1148375fbbbf637aa7a
sha512sum(kubernetes-client-linux-amd64.tar.gz)=7e65358a19b4eabfbbf886061098d7edc1268ab59a3e0f813a264ff525bed8c76f4f0bd5bcb151d8a05dcb1b2f25d874e2346d448725e701614439a27f960079

Extracting /home/cdufour/github/exoscale/pkg-kubernetes/download/client/kubernetes-client-linux-amd64.tar.gz into /home/cdufour/github/exoscale/pkg-kubernetes/download/platforms/linux/amd64
Add '/home/cdufour/github/exoscale/pkg-kubernetes/download/client/bin' to your PATH to use newly-installed binaries.
tar -xf "./download/server/kubernetes-server-linux-amd64.tar.gz" --wildcards '*/server/bin/*'
kubernetes/server/bin/kubectl completion bash > kubectl.bash_completion
make[1]: Leaving directory '/local/data/encrypted/github/exoscale/pkg-kubernetes'
 fakeroot debian/rules binary
dh binary --with=systemd,bash-completion
   dh_testroot
   dh_prep
   dh_installdirs
   dh_install
   dh_installdocs
   dh_installchangelogs
   dh_bash-completion
   dh_systemd_enable
   dh_installinit
   debian/rules override_dh_systemd_start
make[1]: Entering directory '/local/data/encrypted/github/exoscale/pkg-kubernetes'
dh_systemd_start --no-restart-after-upgrade --no-restart-on-upgrade
make[1]: Leaving directory '/local/data/encrypted/github/exoscale/pkg-kubernetes'
   dh_installlogrotate
   dh_perl
   dh_link
   dh_strip_nondeterminism
   dh_compress
   dh_fixperms
   dh_missing
   dh_strip
   dh_makeshlibs
   dh_shlibdeps
   dh_installdeb
   debian/rules override_dh_gencontrol
make[1]: Entering directory '/local/data/encrypted/github/exoscale/pkg-kubernetes'
dh_gencontrol -- -v1.19.4-0+exo5~buster
make[1]: Leaving directory '/local/data/encrypted/github/exoscale/pkg-kubernetes'
   dh_md5sums
   dh_builddeb
dpkg-deb: building package 'kube-common' in '../kube-common_1.19.4-0+exo5~buster_all.deb'.
dpkg-deb: building package 'kube-apiserver' in '../kube-apiserver_1.19.4-0+exo5~buster_amd64.deb'.
dpkg-deb: building package 'kubectl' in '../kubectl_1.19.4-0+exo5~buster_amd64.deb'.
dpkg-deb: building package 'kube-controller-manager' in '../kube-controller-manager_1.19.4-0+exo5~buster_amd64.deb'.
dpkg-deb: building package 'kube-scheduler' in '../kube-scheduler_1.19.4-0+exo5~buster_amd64.deb'.
dpkg-deb: building package 'kubelet' in '../kubelet_1.19.4-0+exo5~buster_amd64.deb'.
dpkg-deb: building package 'kubeadm' in '../kubeadm_1.19.4-0+exo5~buster_amd64.deb'.
dpkg-deb: building package 'kubernetes-master' in '../kubernetes-master_1.19.4-0+exo5~buster_all.deb'.
 dpkg-genbuildinfo --build=binary
 dpkg-genchanges --build=binary >../kubernetes_1.19.4-0+exo5_amd64.changes
dpkg-genchanges: info: binary-only upload (no source code included)
 dpkg-source --after-build .
dpkg-buildpackage: info: binary-only upload (no source included)
@ 2020-11-24 11:29:51 +0100

* cdufour@xps13-9380.cedric.exoscale.me:~/github/exoscale/pkg-kubernetes (cedric/ch22294/debian-even-better-focal)
$ for p in ../kube*exo5*.deb; do echo ==========; echo $p; dpkg -I $p; dpkg -c $p; done
==========
../kubeadm_1.19.4-0+exo5~buster_amd64.deb
 new Debian package, version 2.0.
 size 7761380 bytes: control archive=544 bytes.
     278 bytes,    10 lines      control              
     192 bytes,     3 lines      md5sums              
 Package: kubeadm
 Source: kubernetes (1.19.4-0+exo5)
 Version: 1.19.4-0+exo5~buster
 Architecture: amd64
 Maintainer: Exoscale <ops@exoscale.com>
 Installed-Size: 38212
 Section: admin
 Priority: optional
 Homepage: https://kubernetes.io/
 Description: Kubernetes administration toolbox
drwxr-xr-x root/root         0 2020-11-24 11:22 ./
drwxr-xr-x root/root         0 2020-11-24 11:22 ./usr/
drwxr-xr-x root/root         0 2020-11-24 11:22 ./usr/bin/
-rwxr-xr-x root/root  39108320 2020-11-24 11:22 ./usr/bin/kubeadm
drwxr-xr-x root/root         0 2020-11-24 11:22 ./usr/share/
drwxr-xr-x root/root         0 2020-11-24 11:22 ./usr/share/doc/
drwxr-xr-x root/root         0 2020-11-24 11:22 ./usr/share/doc/kubeadm/
-rw-r--r-- root/root       543 2020-11-24 11:22 ./usr/share/doc/kubeadm/changelog.Debian.gz
-rw-r--r-- root/root     11358 2020-11-20 13:03 ./usr/share/doc/kubeadm/copyright
==========
../kube-apiserver_1.19.4-0+exo5~buster_amd64.deb
 new Debian package, version 2.0.
 size 18547780 bytes: control archive=1336 bytes.
      28 bytes,     1 lines      conffiles            
     340 bytes,    11 lines      control              
     355 bytes,     5 lines      md5sums              
    1636 bytes,    35 lines   *  postinst             #!/bin/sh
     814 bytes,    26 lines   *  postrm               #!/bin/sh
     401 bytes,    12 lines   *  prerm                #!/bin/sh
 Package: kube-apiserver
 Source: kubernetes (1.19.4-0+exo5)
 Version: 1.19.4-0+exo5~buster
 Architecture: amd64
 Maintainer: Exoscale <ops@exoscale.com>
 Installed-Size: 112598
 Depends: kube-common (= 1.19.4-0+exo5~buster)
 Section: admin
 Priority: optional
 Homepage: https://kubernetes.io/
 Description: Kubernetes Master Components - API Server
drwxr-xr-x root/root         0 2020-11-24 11:22 ./
drwxr-xr-x root/root         0 2020-11-24 11:22 ./etc/
drwxr-xr-x root/root         0 2020-11-24 11:22 ./etc/default/
-rw-r--r-- root/root      2372 2020-11-23 18:05 ./etc/default/kube-apiserver
drwxr-xr-x root/root         0 2020-11-24 11:22 ./etc/kubernetes/
drwxr-xr-x root/root         0 2020-11-24 11:22 ./etc/kubernetes/apiserver/
drwxr-xr-x root/root         0 2020-11-24 11:22 ./lib/
drwxr-xr-x root/root         0 2020-11-24 11:22 ./lib/systemd/
drwxr-xr-x root/root         0 2020-11-24 11:22 ./lib/systemd/system/
-rw-r--r-- root/root       491 2020-11-20 13:03 ./lib/systemd/system/kube-apiserver.service
drwxr-xr-x root/root         0 2020-11-24 11:22 ./usr/
drwxr-xr-x root/root         0 2020-11-24 11:22 ./usr/bin/
-rwxr-xr-x root/root 115257440 2020-11-24 11:22 ./usr/bin/kube-apiserver
-rwxr-xr-x root/root      4772 2020-11-20 13:03 ./usr/bin/kube-apiserver.launcher
drwxr-xr-x root/root         0 2020-11-24 11:22 ./usr/share/
drwxr-xr-x root/root         0 2020-11-24 11:22 ./usr/share/doc/
drwxr-xr-x root/root         0 2020-11-24 11:22 ./usr/share/doc/kube-apiserver/
-rw-r--r-- root/root       543 2020-11-24 11:22 ./usr/share/doc/kube-apiserver/changelog.Debian.gz
-rw-r--r-- root/root     11358 2020-11-20 13:03 ./usr/share/doc/kube-apiserver/copyright
==========
../kube-common_1.19.4-0+exo5~buster_all.deb
 new Debian package, version 2.0.
 size 6096 bytes: control archive=944 bytes.
      29 bytes,     1 lines      conffiles            
     273 bytes,    10 lines      control              
     150 bytes,     2 lines      md5sums              
     757 bytes,    30 lines   *  postinst             #!/bin/sh
 Package: kube-common
 Source: kubernetes (1.19.4-0+exo5)
 Version: 1.19.4-0+exo5~buster
 Architecture: all
 Maintainer: Exoscale <ops@exoscale.com>
 Installed-Size: 30
 Section: admin
 Priority: optional
 Homepage: https://kubernetes.io/
 Description: Kubernetes - common resources
drwxr-xr-x root/root         0 2020-11-24 11:22 ./
drwxr-xr-x root/root         0 2020-11-24 11:22 ./etc/
drwxr-xr-x root/root         0 2020-11-24 11:22 ./etc/kubernetes/
drwxr-xr-x root/root         0 2020-11-24 11:22 ./etc/logrotate.d/
-rw-r--r-- root/root       393 2020-11-20 13:03 ./etc/logrotate.d/kube-common
drwxr-xr-x root/root         0 2020-11-24 11:22 ./usr/
drwxr-xr-x root/root         0 2020-11-24 11:22 ./usr/share/
drwxr-xr-x root/root         0 2020-11-24 11:22 ./usr/share/doc/
drwxr-xr-x root/root         0 2020-11-24 11:22 ./usr/share/doc/kube-common/
-rw-r--r-- root/root       543 2020-11-24 11:22 ./usr/share/doc/kube-common/changelog.Debian.gz
-rw-r--r-- root/root     11358 2020-11-20 13:03 ./usr/share/doc/kube-common/copyright
drwxr-xr-x root/root         0 2020-11-24 11:22 ./var/
drwxr-xr-x root/root         0 2020-11-24 11:22 ./var/lib/
drwxr-xr-x root/root         0 2020-11-24 11:22 ./var/lib/kubernetes/
drwxr-xr-x root/root         0 2020-11-24 11:22 ./var/log/
drwxr-xr-x root/root         0 2020-11-24 11:22 ./var/log/kubernetes/
==========
../kube-controller-manager_1.19.4-0+exo5~buster_amd64.deb
 new Debian package, version 2.0.
 size 17476112 bytes: control archive=1352 bytes.
      37 bytes,     1 lines      conffiles            
     357 bytes,    11 lines      control              
     400 bytes,     5 lines      md5sums              
    1708 bytes,    35 lines   *  postinst             #!/bin/sh
     850 bytes,    26 lines   *  postrm               #!/bin/sh
     428 bytes,    12 lines   *  prerm                #!/bin/sh
 Package: kube-controller-manager
 Source: kubernetes (1.19.4-0+exo5)
 Version: 1.19.4-0+exo5~buster
 Architecture: amd64
 Maintainer: Exoscale <ops@exoscale.com>
 Installed-Size: 104803
 Depends: kube-common (= 1.19.4-0+exo5~buster)
 Section: admin
 Priority: optional
 Homepage: https://kubernetes.io/
 Description: Kubernetes Master Components - Controller-Manager
drwxr-xr-x root/root         0 2020-11-24 11:22 ./
drwxr-xr-x root/root         0 2020-11-24 11:22 ./etc/
drwxr-xr-x root/root         0 2020-11-24 11:22 ./etc/default/
-rw-r--r-- root/root      1080 2020-11-23 18:19 ./etc/default/kube-controller-manager
drwxr-xr-x root/root         0 2020-11-24 11:22 ./etc/kubernetes/
drwxr-xr-x root/root         0 2020-11-24 11:22 ./etc/kubernetes/controller-manager/
drwxr-xr-x root/root         0 2020-11-24 11:22 ./lib/
drwxr-xr-x root/root         0 2020-11-24 11:22 ./lib/systemd/
drwxr-xr-x root/root         0 2020-11-24 11:22 ./lib/systemd/system/
-rw-r--r-- root/root       594 2020-11-20 13:03 ./lib/systemd/system/kube-controller-manager.service
drwxr-xr-x root/root         0 2020-11-24 11:22 ./usr/
drwxr-xr-x root/root         0 2020-11-24 11:22 ./usr/bin/
-rwxr-xr-x root/root 107276512 2020-11-24 11:22 ./usr/bin/kube-controller-manager
-rwxr-xr-x root/root      4788 2020-11-20 13:03 ./usr/bin/kube-controller-manager.launcher
drwxr-xr-x root/root         0 2020-11-24 11:22 ./usr/share/
drwxr-xr-x root/root         0 2020-11-24 11:22 ./usr/share/doc/
drwxr-xr-x root/root         0 2020-11-24 11:22 ./usr/share/doc/kube-controller-manager/
-rw-r--r-- root/root       543 2020-11-24 11:22 ./usr/share/doc/kube-controller-manager/changelog.Debian.gz
-rw-r--r-- root/root     11358 2020-11-20 13:03 ./usr/share/doc/kube-controller-manager/copyright
==========
../kubectl_1.19.4-0+exo5~buster_amd64.deb
 new Debian package, version 2.0.
 size 8365688 bytes: control archive=620 bytes.
     350 bytes,    11 lines      control              
     272 bytes,     4 lines      md5sums              
 Package: kubectl
 Source: kubernetes (1.19.4-0+exo5)
 Version: 1.19.4-0+exo5~buster
 Architecture: amd64
 Maintainer: Exoscale <ops@exoscale.com>
 Installed-Size: 42428
 Breaks: kubelet (<< 1.19.4-0+exo4~), kubernetes-master (<< 1.19.4-0+exo4~)
 Section: admin
 Priority: optional
 Homepage: https://kubernetes.io/
 Description: Kubernetes command-line client
drwxr-xr-x root/root         0 2020-11-24 11:22 ./
drwxr-xr-x root/root         0 2020-11-24 11:22 ./usr/
drwxr-xr-x root/root         0 2020-11-24 11:22 ./usr/bin/
-rwxr-xr-x root/root  43004032 2020-11-24 11:22 ./usr/bin/kubectl
drwxr-xr-x root/root         0 2020-11-24 11:22 ./usr/share/
drwxr-xr-x root/root         0 2020-11-24 11:22 ./usr/share/bash-completion/
drwxr-xr-x root/root         0 2020-11-24 11:22 ./usr/share/bash-completion/completions/
-rw-r--r-- root/root    418332 2020-11-24 11:22 ./usr/share/bash-completion/completions/kubectl
drwxr-xr-x root/root         0 2020-11-24 11:22 ./usr/share/doc/
drwxr-xr-x root/root         0 2020-11-24 11:22 ./usr/share/doc/kubectl/
-rw-r--r-- root/root       543 2020-11-24 11:22 ./usr/share/doc/kubectl/changelog.Debian.gz
-rw-r--r-- root/root     11358 2020-11-20 13:03 ./usr/share/doc/kubectl/copyright
==========
../kubelet_1.19.4-0+exo5~buster_amd64.deb
 new Debian package, version 2.0.
 size 18219900 bytes: control archive=1372 bytes.
      21 bytes,     1 lines      conffiles            
     380 bytes,    11 lines      control              
     396 bytes,     6 lines      md5sums              
    1580 bytes,    35 lines   *  postinst             #!/bin/sh
     786 bytes,    26 lines   *  postrm               #!/bin/sh
     380 bytes,    12 lines   *  prerm                #!/bin/sh
 Package: kubelet
 Source: kubernetes (1.19.4-0+exo5)
 Version: 1.19.4-0+exo5~buster
 Architecture: amd64
 Maintainer: Exoscale <ops@exoscale.com>
 Installed-Size: 107478
 Depends: libc6 (>= 2.3.2), kubectl (= 1.19.4-0+exo5~buster), kube-common (= 1.19.4-0+exo5~buster)
 Section: admin
 Priority: optional
 Homepage: https://kubernetes.io/
 Description: Kubernetes Node Components - kubelet
drwxr-xr-x root/root         0 2020-11-24 11:22 ./
drwxr-xr-x root/root         0 2020-11-24 11:22 ./etc/
drwxr-xr-x root/root         0 2020-11-24 11:22 ./etc/default/
-rw-r--r-- root/root       721 2020-11-20 13:03 ./etc/default/kubelet
drwxr-xr-x root/root         0 2020-11-24 11:22 ./etc/kubernetes/
drwxr-xr-x root/root         0 2020-11-24 11:22 ./etc/kubernetes/kubelet/
drwxr-xr-x root/root         0 2020-11-24 11:22 ./lib/
drwxr-xr-x root/root         0 2020-11-24 11:22 ./lib/systemd/
drwxr-xr-x root/root         0 2020-11-24 11:22 ./lib/systemd/system/
-rw-r--r-- root/root       534 2020-11-20 13:03 ./lib/systemd/system/kubelet.service
drwxr-xr-x root/root         0 2020-11-24 11:22 ./usr/
drwxr-xr-x root/root         0 2020-11-24 11:22 ./usr/bin/
-rwxr-xr-x root/root 110015360 2020-11-24 11:22 ./usr/bin/kubelet
-rwxr-xr-x root/root      4776 2020-11-20 13:03 ./usr/bin/kubelet.launcher
drwxr-xr-x root/root         0 2020-11-24 11:22 ./usr/share/
drwxr-xr-x root/root         0 2020-11-24 11:22 ./usr/share/doc/
drwxr-xr-x root/root         0 2020-11-24 11:22 ./usr/share/doc/kubelet/
-rw-r--r-- root/root       543 2020-11-24 11:22 ./usr/share/doc/kubelet/changelog.Debian.gz
-rw-r--r-- root/root     11358 2020-11-20 13:03 ./usr/share/doc/kubelet/copyright
-rw-r--r-- root/root      1170 2020-11-20 13:03 ./usr/share/doc/kubelet/kubelet.config.yaml
==========
../kubernetes-master_1.19.4-0+exo5~buster_all.deb
 new Debian package, version 2.0.
 size 5432 bytes: control archive=584 bytes.
     487 bytes,    11 lines      control              
     162 bytes,     2 lines      md5sums              
 Package: kubernetes-master
 Source: kubernetes (1.19.4-0+exo5)
 Version: 1.19.4-0+exo5~buster
 Architecture: all
 Maintainer: Exoscale <ops@exoscale.com>
 Installed-Size: 19
 Depends: kube-apiserver (= 1.19.4-0+exo5~buster), kube-controller-manager (= 1.19.4-0+exo5~buster), kube-scheduler (= 1.19.4-0+exo5~buster), kubectl (= 1.19.4-0+exo5~buster)
 Section: admin
 Priority: optional
 Homepage: https://kubernetes.io/
 Description: Kubernetes Master Components - Full Control Plane (metapackage)
drwxr-xr-x root/root         0 2020-11-24 11:22 ./
drwxr-xr-x root/root         0 2020-11-24 11:22 ./usr/
drwxr-xr-x root/root         0 2020-11-24 11:22 ./usr/share/
drwxr-xr-x root/root         0 2020-11-24 11:22 ./usr/share/doc/
drwxr-xr-x root/root         0 2020-11-24 11:22 ./usr/share/doc/kubernetes-master/
-rw-r--r-- root/root       543 2020-11-24 11:22 ./usr/share/doc/kubernetes-master/changelog.Debian.gz
-rw-r--r-- root/root     11358 2020-11-20 13:03 ./usr/share/doc/kubernetes-master/copyright
==========
../kube-scheduler_1.19.4-0+exo5~buster_amd64.deb
 new Debian package, version 2.0.
 size 8376992 bytes: control archive=1336 bytes.
      28 bytes,     1 lines      conffiles            
     338 bytes,    11 lines      control              
     355 bytes,     5 lines      md5sums              
    1636 bytes,    35 lines   *  postinst             #!/bin/sh
     814 bytes,    26 lines   *  postrm               #!/bin/sh
     401 bytes,    12 lines   *  prerm                #!/bin/sh
 Package: kube-scheduler
 Source: kubernetes (1.19.4-0+exo5)
 Version: 1.19.4-0+exo5~buster
 Architecture: amd64
 Maintainer: Exoscale <ops@exoscale.com>
 Installed-Size: 41178
 Depends: kube-common (= 1.19.4-0+exo5~buster)
 Section: admin
 Priority: optional
 Homepage: https://kubernetes.io/
 Description: Kubernetes Master Components - Scheduler
drwxr-xr-x root/root         0 2020-11-24 11:22 ./
drwxr-xr-x root/root         0 2020-11-24 11:22 ./etc/
drwxr-xr-x root/root         0 2020-11-24 11:22 ./etc/default/
-rw-r--r-- root/root       778 2020-11-20 13:03 ./etc/default/kube-scheduler
drwxr-xr-x root/root         0 2020-11-24 11:22 ./etc/kubernetes/
drwxr-xr-x root/root         0 2020-11-24 11:22 ./etc/kubernetes/scheduler/
drwxr-xr-x root/root         0 2020-11-24 11:22 ./lib/
drwxr-xr-x root/root         0 2020-11-24 11:22 ./lib/systemd/
drwxr-xr-x root/root         0 2020-11-24 11:22 ./lib/systemd/system/
-rw-r--r-- root/root       549 2020-11-20 13:03 ./lib/systemd/system/kube-scheduler.service
drwxr-xr-x root/root         0 2020-11-24 11:22 ./usr/
drwxr-xr-x root/root         0 2020-11-24 11:22 ./usr/bin/
-rwxr-xr-x root/root  42127520 2020-11-24 11:22 ./usr/bin/kube-scheduler
-rwxr-xr-x root/root      2336 2020-11-20 13:03 ./usr/bin/kube-scheduler.launcher
drwxr-xr-x root/root         0 2020-11-24 11:22 ./usr/share/
drwxr-xr-x root/root         0 2020-11-24 11:22 ./usr/share/doc/
drwxr-xr-x root/root         0 2020-11-24 11:22 ./usr/share/doc/kube-scheduler/
-rw-r--r-- root/root       543 2020-11-24 11:22 ./usr/share/doc/kube-scheduler/changelog.Debian.gz
-rw-r--r-- root/root     11358 2020-11-20 13:03 ./usr/share/doc/kube-scheduler/copyright
@ 2020-11-24 11:39:15 +0100
```