### PR TITLE
Release 1.20.0

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+kubernetes (1.20.0-0+exo1) UNRELEASED; urgency=low
+
+  * Package 1.20.0
+
+ -- Sebastian Krohn <sebastian.krohn@exoscale.ch>  Tue, 14 Dec 2020 17:31:31 +0100
+
 kubernetes (1.19.4-0+exo6) UNRELEASED; urgency=low
 
   * debian: FIX broken packages (kube-{apiserver,controller-manager,scheduler} <-> kubernetes-master)

--- a/debian/control
+++ b/debian/control
@@ -13,19 +13,19 @@ Description: Kubernetes - common resources
 Package: kube-apiserver
 Architecture: any
 Depends: kube-common (= ${binary:Version})
-Breaks: kubernetes-master (<< 1.19.4-0+exo4~)
+Breaks: kubernetes-master (<< 1.20.0-0+exo1~)
 Description: Kubernetes Master Components - API Server
 
 Package: kube-controller-manager
 Architecture: any
 Depends: kube-common (= ${binary:Version})
-Breaks: kubernetes-master (<< 1.19.4-0+exo4~)
+Breaks: kubernetes-master (<< 1.20.0-0+exo1~)
 Description: Kubernetes Master Components - Controller-Manager
 
 Package: kube-scheduler
 Architecture: any
 Depends: kube-common (= ${binary:Version})
-Breaks: kubernetes-master (<< 1.19.4-0+exo4~)
+Breaks: kubernetes-master (<< 1.20.0-0+exo1~)
 Description: Kubernetes Master Components - Scheduler
 
 Package: kubelet
@@ -35,7 +35,7 @@ Description: Kubernetes Node Components - kubelet
 
 Package: kubectl
 Architecture: any
-Breaks: kubelet (<< 1.19.4-0+exo4~), kubernetes-master (<< 1.19.4-0+exo4~)
+Breaks: kubelet (<< 1.20.0-0+exo1~), kubernetes-master (<< 1.20.0-0+exo1~)
 Description: Kubernetes command-line client
 
 Package: kubeadm


### PR DESCRIPTION

This is focal-only as it's for the gen2 clusters.
