### PR TITLE
debian: add 'socat' as 'kubectl' dependency

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+kubernetes (1.20.2-0+exo3) UNRELEASED; urgency=low
+
+  * Add 'socat' as 'kubectl' dependency
+
+ -- Cédric Dufour <cedric.dufour@exoscale.ch>  Tue, 09 Feb 2021 09:48:36 +0100
+
 kubernetes (1.20.2-0+exo2) UNRELEASED; urgency=low
 
   * Remove logrotate from kube-common

--- a/debian/control
+++ b/debian/control
@@ -35,6 +35,7 @@ Description: Kubernetes Node Components - kubelet
 
 Package: kubectl
 Architecture: any
+Depends: socat
 Breaks: kubelet (<< 1.20.0-0+exo1~), kubernetes-master (<< 1.20.0-0+exo1~)
 Description: Kubernetes command-line client
 


### PR DESCRIPTION
It appears `socat` should be considered a hard-dependency for `kubectl`: https://prefetch.net/blog/2018/02/03/how-the-kubectl-port-forward-command-works/