### PR TITLE
Remove service ExecReload as it seems to have no effect

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,11 @@
+kubernetes (1.20.5-0+exo2) UNRELEASED; urgency=medium
+  * Remove service ExecReload as it seems to have no effect
+
+ -- Antoine <antoine@antoine-exo>  Tue, 30 Mar 2021 15:02:39 +0200
+
 kubernetes (1.20.5-0+exo1) UNRELEASED; urgency=medium
 
-  * New upstream release: 1.20.5, https://github.com/kubernetes/kubernetes/releases/tag/v1.20.5 
+  * New upstream release: 1.20.5, https://github.com/kubernetes/kubernetes/releases/tag/v1.20.5
 
  -- Alexandros Afentoulis <alexandros.afentoulis@exoscale.ch>  Fri, 19 Mar 2021 11:47:44 +0200
 

--- a/debian/kube-apiserver.service
+++ b/debian/kube-apiserver.service
@@ -11,7 +11,6 @@ Group=kube
 EnvironmentFile=/etc/default/kube-apiserver
 ExecCondition=/usr/bin/test -n "$KUBE_APISERVER_ENABLE"
 ExecStart=/usr/bin/kube-apiserver.launcher
-ExecReload=/bin/kill --signal HUP $MAINPID
 Restart=on-failure
 RestartSec=5
 TimeoutStopSec=60

--- a/debian/kube-controller-manager.service
+++ b/debian/kube-controller-manager.service
@@ -12,7 +12,6 @@ Group=kube
 EnvironmentFile=/etc/default/kube-controller-manager
 ExecCondition=/usr/bin/test -n "$KUBE_CONTROLLER_MANAGER_ENABLE"
 ExecStart=/usr/bin/kube-controller-manager.launcher
-ExecReload=/bin/kill --signal HUP $MAINPID
 Restart=on-failure
 RestartSec=5
 TimeoutStopSec=60

--- a/debian/kube-scheduler.service
+++ b/debian/kube-scheduler.service
@@ -12,7 +12,6 @@ Group=kube
 EnvironmentFile=/etc/default/kube-scheduler
 ExecCondition=/usr/bin/test -n "$KUBE_SCHEDULER_ENABLE"
 ExecStart=/usr/bin/kube-scheduler.launcher
-ExecReload=/bin/kill --signal HUP $MAINPID
 Restart=on-failure
 RestartSec=5
 TimeoutStopSec=60

--- a/debian/kubelet.service
+++ b/debian/kubelet.service
@@ -10,7 +10,6 @@ StartLimitBurst=3
 EnvironmentFile=/etc/default/kubelet
 ExecCondition=/usr/bin/test -n "$KUBELET_ENABLE"
 ExecStart=/usr/bin/kubelet.launcher
-ExecReload=/bin/kill --signal HUP $MAINPID
 Restart=on-failure
 RestartSec=5
 TimeoutStopSec=60


### PR DESCRIPTION
It looks like SIGHUP is handled [the same way as SIGTERM or SIGINT](https://github.com/kubernetes/kubernetes/blob/v1.20.5/pkg/util/interrupt/interrupt.go#L26-L28), so it doesn't make sense to keep this `ExecReload` confusing people into thinking that the program will reload its configuration without restarting.
