### PR TITLE
kupe-apiserver.service: bump TimeoutStopSec to 180s [FIX]

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+kubernetes (1.21.0-0+exo2) UNRELEASED; urgency=low
+
+  * kupe-apiserver.service: bump TimeoutStopSec to 180s
+
+ -- Cédric Dufour <cedric.dufour@exoscale.ch>  Thu, 29 Apr 2021 16:43:19 +0200
+
 kubernetes (1.21.0-0+exo1) UNRELEASED; urgency=medium
 
   * New upstream release 1.21.0

--- a/debian/kube-apiserver.service
+++ b/debian/kube-apiserver.service
@@ -13,7 +13,7 @@ ExecCondition=/usr/bin/test -n "$KUBE_APISERVER_ENABLE"
 ExecStart=/usr/bin/kube-apiserver.launcher
 Restart=on-failure
 RestartSec=5
-TimeoutStopSec=60
+TimeoutStopSec=180
 LimitNOFILE=65536
 LimitMEMLOCK=infinity
 


### PR DESCRIPTION
`kube-apiserver` may take more than 60 seconds to shut down, especially considering the extra delay added by `--shutdown-delay-duration=30s`; example given (with fix applied):
```
* root@kube-master-pp004.gv2.p.exoscale.net:~
# date; _so kube-apiserver.service; _ss kube-apiserver.service
Thu Apr 29 14:34:56 UTC 2021
# [systemctl stop]
# [systemctl status]
● kube-apiserver.service - "Kubernetes API Server"
     Loaded: loaded (/etc/systemd/system/kube-apiserver.service; enabled; vendor preset: enabled)
     Active: inactive (dead) since Thu 2021-04-29 14:36:26 UTC; 18ms ago
    Process: 2259447 ExecStart=/usr/bin/kube-apiserver --advertise-address=89.145.166.36 --allow-privileged=true --apiserver-count=2 --authorizatio>
   Main PID: 2259447 (code=exited, status=0/SUCCESS)

Apr 29 14:36:13 kube-master-pp004 kube-apiserver[2259447]: {"ts":1619706973917.3574,"msg":"pickfirstBalancer: HandleSubConnStateChange: 0xc01513377>
Apr 29 14:36:13 kube-master-pp004 kube-apiserver[2259447]: {"ts":1619706973919.3223,"msg":"transport: loopyWriter.run returning. connection error: >
Apr 29 14:36:17 kube-master-pp004 kube-apiserver[2259447]: {"ts":1619706977868.9622,"msg":"parsed scheme: \"passthrough\"\n","v":0}
Apr 29 14:36:17 kube-master-pp004 kube-apiserver[2259447]: {"ts":1619706977869.0864,"msg":"ccResolverWrapper: sending update to cc: {[{https://kube>
Apr 29 14:36:17 kube-master-pp004 kube-apiserver[2259447]: {"ts":1619706977869.1113,"msg":"ClientConn switching balancer to \"pick_first\"\n","v":0}
Apr 29 14:36:17 kube-master-pp004 kube-apiserver[2259447]: {"ts":1619706977869.7805,"msg":"pickfirstBalancer: HandleSubConnStateChange: 0xc00e2a010>
Apr 29 14:36:17 kube-master-pp004 kube-apiserver[2259447]: {"ts":1619706977887.715,"msg":"pickfirstBalancer: HandleSubConnStateChange: 0xc00e2a0100>
Apr 29 14:36:17 kube-master-pp004 kube-apiserver[2259447]: {"ts":1619706977889.1511,"msg":"transport: loopyWriter.run returning. connection error: >
Apr 29 14:36:26 kube-master-pp004 systemd[1]: kube-apiserver.service: Succeeded.
Apr 29 14:36:26 kube-master-pp004 systemd[1]: Stopped "Kubernetes API Server".
```

Without the fix, the process would have been `kill -9` after 60s (and _ungracefully_ shut down)
